### PR TITLE
[ADD] load balance สำหรับ  static file บน NGINX

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -59,3 +59,16 @@ server {
     #    deny  all;
     #}
 }
+# use for reverse proxy in gamer docuemnt
+server {
+  listen 4321 default_server;
+  listen [::]:4321;
+  root  /usr/share/nginx/html;
+  # LB : LoadBalance path in rancher like /v1/news/docs
+  location ___LB_PATH___ {  
+    autoindex on;
+    alias /usr/share/nginx/html;
+  }
+}
+
+


### PR DESCRIPTION
บน rancher มันมีการนำ path ของ LB ไปเติมต่อเองทำให้ไม่สามารถเข้าผ่าน path ปกติๆได้ เหมือนทัวๆไป ที่ภายใน root ที่ folder งานเราแต่มันดันไปเติม request path ของ lb ด้วยวิธีแก้เลยก็คือ นำ request path ของ LB ไปเรียก path เดิมแทน ก็คือ alias นั่นเอง สำหรับใครที่ต้องการนำ static fiile มาแสดงผลบน nginx ก็ทำได้โดย staticfile จะอยู่บน port 4321